### PR TITLE
Add missing SlideKit package dependency to sample apps

### DIFF
--- a/SlideKitDemo-iOS/SlideKitDemo-iOS.xcodeproj/project.pbxproj
+++ b/SlideKitDemo-iOS/SlideKitDemo-iOS.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		1808A4D228B6751900E7AC77 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1808A4D128B6751900E7AC77 /* SceneDelegate.swift */; };
 		1808A4D528B6752800E7AC77 /* SlideKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1808A4D428B6752800E7AC77 /* SlideKit */; };
 		1808A4DB28B677F200E7AC77 /* TitleSlide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1808A4DA28B677F200E7AC77 /* TitleSlide.swift */; };
+		68642A142D609659008288D1 /* SlideKit in Frameworks */ = {isa = PBXBuildFile; productRef = 68642A132D609659008288D1 /* SlideKit */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -35,6 +36,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1808A4D528B6752800E7AC77 /* SlideKit in Frameworks */,
+				68642A142D609659008288D1 /* SlideKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -114,6 +116,7 @@
 			name = "SlideKitDemo-iOS";
 			packageProductDependencies = (
 				1808A4D428B6752800E7AC77 /* SlideKit */,
+				68642A132D609659008288D1 /* SlideKit */,
 			);
 			productName = "SlideKitDemo-iOS";
 			productReference = 1808A4BE28B674A500E7AC77 /* SlideKitDemo-iOS.app */;
@@ -143,6 +146,9 @@
 				Base,
 			);
 			mainGroup = 1808A4B528B674A500E7AC77;
+			packageReferences = (
+				68642A122D609659008288D1 /* XCRemoteSwiftPackageReference "SlideKit" */,
+			);
 			productRefGroup = 1808A4BF28B674A500E7AC77 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -375,9 +381,25 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		68642A122D609659008288D1 /* XCRemoteSwiftPackageReference "SlideKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mtj0928/SlideKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.5.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		1808A4D428B6752800E7AC77 /* SlideKit */ = {
 			isa = XCSwiftPackageProductDependency;
+			productName = SlideKit;
+		};
+		68642A132D609659008288D1 /* SlideKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 68642A122D609659008288D1 /* XCRemoteSwiftPackageReference "SlideKit" */;
 			productName = SlideKit;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/SlideKitDemo-iOS/SlideKitDemo-iOS.xcodeproj/project.pbxproj
+++ b/SlideKitDemo-iOS/SlideKitDemo-iOS.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -13,9 +13,8 @@
 		1808A4C928B674A600E7AC77 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1808A4C828B674A600E7AC77 /* Preview Assets.xcassets */; };
 		1808A4D028B674CB00E7AC77 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1808A4CF28B674CB00E7AC77 /* AppDelegate.swift */; };
 		1808A4D228B6751900E7AC77 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1808A4D128B6751900E7AC77 /* SceneDelegate.swift */; };
-		1808A4D528B6752800E7AC77 /* SlideKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1808A4D428B6752800E7AC77 /* SlideKit */; };
 		1808A4DB28B677F200E7AC77 /* TitleSlide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1808A4DA28B677F200E7AC77 /* TitleSlide.swift */; };
-		68642A142D609659008288D1 /* SlideKit in Frameworks */ = {isa = PBXBuildFile; productRef = 68642A132D609659008288D1 /* SlideKit */; };
+		682CDF2C2D64C9A30047599C /* SlideKit in Frameworks */ = {isa = PBXBuildFile; productRef = 682CDF2B2D64C9A30047599C /* SlideKit */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -35,8 +34,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1808A4D528B6752800E7AC77 /* SlideKit in Frameworks */,
-				68642A142D609659008288D1 /* SlideKit in Frameworks */,
+				682CDF2C2D64C9A30047599C /* SlideKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -115,8 +113,7 @@
 			);
 			name = "SlideKitDemo-iOS";
 			packageProductDependencies = (
-				1808A4D428B6752800E7AC77 /* SlideKit */,
-				68642A132D609659008288D1 /* SlideKit */,
+				682CDF2B2D64C9A30047599C /* SlideKit */,
 			);
 			productName = "SlideKitDemo-iOS";
 			productReference = 1808A4BE28B674A500E7AC77 /* SlideKitDemo-iOS.app */;
@@ -147,7 +144,7 @@
 			);
 			mainGroup = 1808A4B528B674A500E7AC77;
 			packageReferences = (
-				68642A122D609659008288D1 /* XCRemoteSwiftPackageReference "SlideKit" */,
+				682CDF2A2D64C9A30047599C /* XCLocalSwiftPackageReference "../../SlideKit" */,
 			);
 			productRefGroup = 1808A4BF28B674A500E7AC77 /* Products */;
 			projectDirPath = "";
@@ -381,25 +378,16 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		68642A122D609659008288D1 /* XCRemoteSwiftPackageReference "SlideKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mtj0928/SlideKit";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.5.0;
-			};
+/* Begin XCLocalSwiftPackageReference section */
+		682CDF2A2D64C9A30047599C /* XCLocalSwiftPackageReference "../../SlideKit" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../SlideKit;
 		};
-/* End XCRemoteSwiftPackageReference section */
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		1808A4D428B6752800E7AC77 /* SlideKit */ = {
+		682CDF2B2D64C9A30047599C /* SlideKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = SlideKit;
-		};
-		68642A132D609659008288D1 /* SlideKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 68642A122D609659008288D1 /* XCRemoteSwiftPackageReference "SlideKit" */;
 			productName = SlideKit;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/SlideKitDemo-iOS/SlideKitDemo-iOS.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/SlideKitDemo-iOS/SlideKitDemo-iOS.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/SlideKitDemo-iOS/SlideKitDemo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SlideKitDemo-iOS/SlideKitDemo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "c46fef24a11a01831ae22b435dbef09f3474184fcaba07dec5aca2007ffc966f",
+  "pins" : [
+    {
+      "identity" : "slidekit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mtj0928/SlideKit",
+      "state" : {
+        "revision" : "5378ca9cc7393ac9392007f9cbf619f79a40ec81",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "splash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/Splash",
+      "state" : {
+        "revision" : "7f4df436eb78fe64fe2c32c58006e9949fa28ad8",
+        "version" : "0.16.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/SlideKitDemo-iOS/SlideKitDemo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SlideKitDemo-iOS/SlideKitDemo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "c46fef24a11a01831ae22b435dbef09f3474184fcaba07dec5aca2007ffc966f",
+  "originHash" : "b36d783c9fa1b0130fec7c57cbce245a7776e516a27e654188e3e5cea7d56982",
   "pins" : [
-    {
-      "identity" : "slidekit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mtj0928/SlideKit",
-      "state" : {
-        "revision" : "5378ca9cc7393ac9392007f9cbf619f79a40ec81",
-        "version" : "0.5.0"
-      }
-    },
     {
       "identity" : "splash",
       "kind" : "remoteSourceControl",

--- a/SlideKitDemo-macOS/SlideKitDemo-macOS.xcodeproj/project.pbxproj
+++ b/SlideKitDemo-macOS/SlideKitDemo-macOS.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		04E2C09328B9AA820076F292 /* BasicSlide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E2C09228B9AA820076F292 /* BasicSlide.swift */; };
 		18A8404B28DC91A800139DC1 /* SlideConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A8404A28DC91A800139DC1 /* SlideConfiguration.swift */; };
 		18D33A2D28D54D250095156B /* CustomHeaderStyleSlide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18D33A2C28D54D250095156B /* CustomHeaderStyleSlide.swift */; };
+		68642A172D60971A008288D1 /* SlideKit in Frameworks */ = {isa = PBXBuildFile; productRef = 68642A162D60971A008288D1 /* SlideKit */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				04E2C09028B915A60076F292 /* SlideKit in Frameworks */,
+				68642A172D60971A008288D1 /* SlideKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -113,6 +115,7 @@
 			name = "SlideKitDemo-macOS";
 			packageProductDependencies = (
 				04E2C08F28B915A60076F292 /* SlideKit */,
+				68642A162D60971A008288D1 /* SlideKit */,
 			);
 			productName = "SlideKitDemo-macOS";
 			productReference = 04E2C07C28B9155D0076F292 /* SlideKitDemo-macOS.app */;
@@ -142,6 +145,9 @@
 				Base,
 			);
 			mainGroup = 04E2C07328B9155D0076F292;
+			packageReferences = (
+				68642A152D60971A008288D1 /* XCRemoteSwiftPackageReference "SlideKit" */,
+			);
 			productRefGroup = 04E2C07D28B9155D0076F292 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -372,9 +378,25 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		68642A152D60971A008288D1 /* XCRemoteSwiftPackageReference "SlideKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mtj0928/SlideKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.5.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		04E2C08F28B915A60076F292 /* SlideKit */ = {
 			isa = XCSwiftPackageProductDependency;
+			productName = SlideKit;
+		};
+		68642A162D60971A008288D1 /* SlideKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 68642A152D60971A008288D1 /* XCRemoteSwiftPackageReference "SlideKit" */;
 			productName = SlideKit;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/SlideKitDemo-macOS/SlideKitDemo-macOS.xcodeproj/project.pbxproj
+++ b/SlideKitDemo-macOS/SlideKitDemo-macOS.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -14,7 +14,7 @@
 		04E2C09328B9AA820076F292 /* BasicSlide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E2C09228B9AA820076F292 /* BasicSlide.swift */; };
 		18A8404B28DC91A800139DC1 /* SlideConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A8404A28DC91A800139DC1 /* SlideConfiguration.swift */; };
 		18D33A2D28D54D250095156B /* CustomHeaderStyleSlide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18D33A2C28D54D250095156B /* CustomHeaderStyleSlide.swift */; };
-		68642A172D60971A008288D1 /* SlideKit in Frameworks */ = {isa = PBXBuildFile; productRef = 68642A162D60971A008288D1 /* SlideKit */; };
+		682CDF2F2D64CA1A0047599C /* SlideKit in Frameworks */ = {isa = PBXBuildFile; productRef = 682CDF2E2D64CA1A0047599C /* SlideKit */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -35,7 +35,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				04E2C09028B915A60076F292 /* SlideKit in Frameworks */,
-				68642A172D60971A008288D1 /* SlideKit in Frameworks */,
+				682CDF2F2D64CA1A0047599C /* SlideKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -115,7 +115,7 @@
 			name = "SlideKitDemo-macOS";
 			packageProductDependencies = (
 				04E2C08F28B915A60076F292 /* SlideKit */,
-				68642A162D60971A008288D1 /* SlideKit */,
+				682CDF2E2D64CA1A0047599C /* SlideKit */,
 			);
 			productName = "SlideKitDemo-macOS";
 			productReference = 04E2C07C28B9155D0076F292 /* SlideKitDemo-macOS.app */;
@@ -146,7 +146,7 @@
 			);
 			mainGroup = 04E2C07328B9155D0076F292;
 			packageReferences = (
-				68642A152D60971A008288D1 /* XCRemoteSwiftPackageReference "SlideKit" */,
+				682CDF2D2D64CA1A0047599C /* XCLocalSwiftPackageReference "../../SlideKit" */,
 			);
 			productRefGroup = 04E2C07D28B9155D0076F292 /* Products */;
 			projectDirPath = "";
@@ -378,25 +378,20 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		68642A152D60971A008288D1 /* XCRemoteSwiftPackageReference "SlideKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mtj0928/SlideKit";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.5.0;
-			};
+/* Begin XCLocalSwiftPackageReference section */
+		682CDF2D2D64CA1A0047599C /* XCLocalSwiftPackageReference "../../SlideKit" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../SlideKit;
 		};
-/* End XCRemoteSwiftPackageReference section */
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		04E2C08F28B915A60076F292 /* SlideKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = SlideKit;
 		};
-		68642A162D60971A008288D1 /* SlideKit */ = {
+		682CDF2E2D64CA1A0047599C /* SlideKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 68642A152D60971A008288D1 /* XCRemoteSwiftPackageReference "SlideKit" */;
 			productName = SlideKit;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/SlideKitDemo-macOS/SlideKitDemo-macOS.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/SlideKitDemo-macOS/SlideKitDemo-macOS.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/SlideKitDemo-macOS/SlideKitDemo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SlideKitDemo-macOS/SlideKitDemo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "c46fef24a11a01831ae22b435dbef09f3474184fcaba07dec5aca2007ffc966f",
+  "pins" : [
+    {
+      "identity" : "slidekit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mtj0928/SlideKit",
+      "state" : {
+        "revision" : "5378ca9cc7393ac9392007f9cbf619f79a40ec81",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "splash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/Splash",
+      "state" : {
+        "revision" : "7f4df436eb78fe64fe2c32c58006e9949fa28ad8",
+        "version" : "0.16.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/SlideKitDemo-macOS/SlideKitDemo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SlideKitDemo-macOS/SlideKitDemo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "c46fef24a11a01831ae22b435dbef09f3474184fcaba07dec5aca2007ffc966f",
+  "originHash" : "b36d783c9fa1b0130fec7c57cbce245a7776e516a27e654188e3e5cea7d56982",
   "pins" : [
-    {
-      "identity" : "slidekit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mtj0928/SlideKit",
-      "state" : {
-        "revision" : "5378ca9cc7393ac9392007f9cbf619f79a40ec81",
-        "version" : "0.5.0"
-      }
-    },
     {
       "identity" : "splash",
       "kind" : "remoteSourceControl",


### PR DESCRIPTION
## Add missing SlideKit package dependency to sample apps
- I added missing SlideKit package dependency to iOS/macOS sample app
- I confirmed that sample apps can be built with Xcode16.x

## Add auto generated `contents.xcworkspacedata` file in iOS/macOS sample app
- Added auto generated `contents.xcworkspacedata` files when opened sample project in Xcode