### PR TITLE
Add initializer accepting pre-generated slides to SlideIndexController

### DIFF
--- a/Sources/SlideKit/SlideIndexController.swift
+++ b/Sources/SlideKit/SlideIndexController.swift
@@ -34,6 +34,21 @@ public final class SlideIndexController: ObservableObject {
         self.currentIndex = index
     }
 
+    public init(
+        index: Int = 0,
+        container: ObservableObjectContainer = ObservableObjectContainerKey.defaultValue,
+        slides: [any Slide]
+    ) {
+        self.slides = slides
+        self.objectContainer = container
+
+        guard index < slides.count else {
+            fatalError("index must be less than the number of slides.")
+        }
+        defer { currentScript = currentSlide.script(on: objectContainer) }
+        self.currentIndex = index
+    }
+
     @discardableResult
     public func forward() -> Bool {
         defer { currentScript = currentSlide.script(on: objectContainer) }

--- a/Sources/SlideKit/SlideIndexController.swift
+++ b/Sources/SlideKit/SlideIndexController.swift
@@ -30,8 +30,8 @@ public final class SlideIndexController: ObservableObject {
         guard index < slides.count else {
             fatalError("index must be less than the number of slides.")
         }
-        defer { currentScript = currentSlide.script(on: objectContainer) }
         self.currentIndex = index
+        currentScript = currentSlide.script(on: objectContainer)
     }
 
     public init(

--- a/Sources/SlideKit/SlideIndexController.swift
+++ b/Sources/SlideKit/SlideIndexController.swift
@@ -45,8 +45,8 @@ public final class SlideIndexController: ObservableObject {
         guard index < slides.count else {
             fatalError("index must be less than the number of slides.")
         }
-        defer { currentScript = currentSlide.script(on: objectContainer) }
         self.currentIndex = index
+        currentScript = currentSlide.script(on: objectContainer)
     }
 
     @discardableResult


### PR DESCRIPTION
## Summary

Adds a new initializer to `SlideIndexController` that accepts a pre-generated array of slides, providing more flexibility in how the controller can be initialized.

## Changes

- Added new public initializer with `slides: [any Slide]` parameter

## Motivation

Previously, `SlideIndexController` could only be initialized through the slide builder pattern. This new initializer allows users to:
- Initialize the controller with slides that have been generated externally
- Have more control over slide creation before passing them to the controller
- Simplify scenarios where slides are already available as an array

## Usage Example

```swift
let slides: [any Slide] = [
    // Pre-generated slides
]

let controller = SlideIndexController(
    slides: slides
)
```